### PR TITLE
add support for react@^15

### DIFF
--- a/lib/components/Notification.js
+++ b/lib/components/Notification.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -29,7 +29,7 @@ var seqGen = function seqGen() {
 };
 var seq = seqGen();
 
-var Notification = (function (_React$Component) {
+var Notification = function (_React$Component) {
   _inherits(Notification, _React$Component);
 
   function Notification(props) {
@@ -189,7 +189,7 @@ var Notification = (function (_React$Component) {
   }]);
 
   return Notification;
-})(_react2.default.Component);
+}(_react2.default.Component);
 
 Notification.propTypes = {
   ignore: _react2.default.PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.21",
     "babel-eslint": "^5.0.0-beta6",
-    "babel-loader": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babelify": "^7.2.0",
@@ -51,17 +50,17 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-spec-reporter": "0.0.23",
     "mocha": "^2.3.4",
-    "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3",
+    "react-addons-test-utils": "^0.14.3 || ^15.0.1",
+    "react-dom": "^0.14.3 || ^15.0.1",
     "rimraf": "^2.4.4",
     "sinon": "^1.17.2",
     "watchify": "^3.6.1"
   },
   "dependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3 || ^15.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.3"
+    "react": "^0.14.3 || ^15.0.1"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
React has jumped from minor to major version numbers, so "^0.14.3" now cannot work with the newest React@15. I've also removed babel-loader as it seems to be unneeded but was generating a warning about the missing webpack sibling dependency.