### PR TITLE
Change demo link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This component show nothing in dom element, but trigger HTML5 Web Notification A
 
 ## Demo
 
-[View Demo](http://georgeosddev.github.io/react-web-notification/example/)
+[View Demo](https://georgeosddev.github.io/react-web-notification/example/)
 
 ## Installation
 


### PR DESCRIPTION
The current link go to an http version which displays this message in the console

```
[Deprecation] The Notification API may no longer be used from insecure origins. You should consider switching your application to a secure origin, such as HTTPS. See https://goo.gl/rStTGz for more details.
```

The link in the repo header should also be updated